### PR TITLE
Add support for whitespace control in ftdetect

### DIFF
--- a/ftdetect/jinja.vim
+++ b/ftdetect/jinja.vim
@@ -3,7 +3,7 @@ fun! s:SelectHTML()
 let n = 1
 while n < 50 && n <= line("$")
   " check for jinja
-  if getline(n) =~ '{{.*}}\|{%\s*\(end.*\|extends\|block\|macro\|set\|if\|for\|include\|trans\)\>'
+  if getline(n) =~ '{{.*}}\|{%-\?\s*\(end.*\|extends\|block\|macro\|set\|if\|for\|include\|trans\)\>'
     set ft=jinja
     return
   endif


### PR DESCRIPTION
Docs: http://jinja.pocoo.org/docs/templates/#whitespace-control

Whitespace can be controlled before and after jinja tags by adding a `-` to the
appropriate jinja block marker.

``` python
{% for i in [1,2,3] %}
  # ... SNIP ...
{% endfor %}
```

becomes

``` python
{% for i in [1,2,3] -%}
  # ... SNIP ...
{%- endfor %}
```
