### PR TITLE
Update from upstream: Fix literal \ characters at the end of a string

### DIFF
--- a/syntax/jinja.vim
+++ b/syntax/jinja.vim
@@ -59,8 +59,8 @@ syn match jinjaFunction contained /[a-zA-Z_][a-zA-Z0-9_]*/
 syn match jinjaBlockName contained /[a-zA-Z_][a-zA-Z0-9_]*/
 
 " Jinja template constants
-syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/"/ skip=/\\"/ end=/"/
-syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/'/ skip=/\\'/ end=/'/
+syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/"/ skip=/\(\\\)\@<!\(\(\\\\\)\@>\)*\\"/ end=/"/
+syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/'/ skip=/\(\\\)\@<!\(\(\\\\\)\@>\)*\\'/ end=/'/
 syn match jinjaNumber containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[0-9]\+\(\.[0-9]\+\)\?/
 
 " Operators


### PR DESCRIPTION
Source: https://github.com/mitsuhiko/jinja2/commit/e0615edb7590591356384465fec8413ebbeece8c