### PR TITLE
Change filetype to jinja.html

### DIFF
--- a/ftdetect/jinja.vim
+++ b/ftdetect/jinja.vim
@@ -4,7 +4,7 @@ fun! s:SelectHTML()
   while n < 50 && n <= line("$")
     " check for jinja
     if getline(n) =~ '{{.*}}\|{%-\?\s*\(end.*\|extends\|block\|macro\|set\|if\|for\|include\|trans\)\>'
-      set ft=jinja
+      set ft=jinja.html
       return
     endif
     let n = n + 1


### PR DESCRIPTION
This prefers jinja syntax files still, but allows html ftplugins to
still run for jinja templates.
