### PR TITLE
Apply jinja highlighting atop any filetype's existing scheme

### DIFF
--- a/indent/jinja.vim
+++ b/indent/jinja.vim
@@ -8,5 +8,7 @@ if exists("b:did_indent")
   finish
 endif
 
-" Use HTML formatting rules.
-runtime! indent/html.vim
+" Use HTML formatting rules for filetypes in `ftdetect/jinja.vim`
+if expand('%:e') =~ 'htm\|nunj|jinja\|j2'
+  runtime! indent/html.vim
+endif

--- a/syntax/jinja.vim
+++ b/syntax/jinja.vim
@@ -23,8 +23,8 @@ if !exists("main_syntax")
   if version < 600
     syntax clear
   elseif exists("b:current_syntax")
-  finish
-endif
+    finish
+  endif
   let main_syntax = 'jinja'
 endif
 
@@ -33,7 +33,13 @@ if g:jinja_syntax_html
   if version < 600
     so <sfile>:p:h/html.vim
   else
-    runtime! syntax/html.vim
+    let ext = expand('%:e')
+    if ext !~ 'htm\|nunj|jinja\|j2' &&
+          \ findfile(ext . '.vim', $VIMRUNTIME . '/syntax') != ''
+      execute 'runtime! syntax/' . ext . '.vim'
+    else
+      runtime! syntax/html.vim
+    endif
     unlet b:current_syntax
   endif
 endif


### PR DESCRIPTION
It's nice to preserve highlighting schemes from native `:syn-files` when using jinja with non-`.html` filetypes.

* Must be set explicitly with something like `:set ft=jinja` or via modeline.
* Only works if the file's extension is not among those auto-detected by this plugin.
* Behaves as if additional syntax rules existed as an `after/syntax` file in `&rtp`.