### PR TITLE
Add support for .tera

### DIFF
--- a/ftdetect/jinja.vim
+++ b/ftdetect/jinja.vim
@@ -11,4 +11,4 @@ fun! s:SelectHTML()
   endwhile
 endfun
 autocmd BufNewFile,BufRead *.html,*.htm,*.nunjucks,*.nunjs,*.njk  call s:SelectHTML()
-autocmd BufNewFile,BufRead *.jinja2,*.j2,*.jinja set ft=jinja
+autocmd BufNewFile,BufRead *.jinja2,*.j2,*.jinja *.tera set ft=jinja


### PR DESCRIPTION
Tera is a rust template engine with basically identical syntax to jinja2. With this patch, jinja.vim will support it as well.