### PR TITLE
Load syntax/BASE.vim for whatever.BASE.j2 files

### DIFF
--- a/syntax/jinja.vim
+++ b/syntax/jinja.vim
@@ -34,6 +34,10 @@ if g:jinja_syntax_html
     so <sfile>:p:h/html.vim
   else
     let ext = expand('%:e')
+    " If file is named like whatever.BASE.j2 try to load BASE syntax
+    if ext == 'j2'
+        let ext = expand('%:r:e')
+    endif
     if ext !~ 'htm\|nunj|jinja\|j2' &&
           \ findfile(ext . '.vim', $VIMRUNTIME . '/syntax') != ''
       execute 'runtime! syntax/' . ext . '.vim'


### PR DESCRIPTION
This did bite us, when we were editing loads of whatever.conf.j2 files. With this change, it will work nicely.