### PR TITLE
update to 2020-04-12 version, unlink from Jinja repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,4 @@ There are two reasons I made this repository:
 
 - I wanted to manage this syntax file with vim-addons-manager or whatever other vim plugins managers there are.
 
-The current version is the [2020-01-06 version](https://github.com/pallets/jinja/commit/d31e66c6ba5a9b4e8b610608f1a9bc114c3ec23c) from the official jinja repository.
-If you notice there is a newer version available please send a pull request.
-
-**If you have bugs or pull requests, please submit them straight to the [source](https://github.com/mitsuhiko/jinja2).** If the plugin is overzealous in detecting the Jinja syntax, send me the template it shouldn't have matched.
+If the plugin is overzealous in detecting the Jinja syntax, send me the template it shouldn't have matched.

--- a/syntax/jinja.vim
+++ b/syntax/jinja.vim
@@ -88,9 +88,6 @@ syn region jinjaRaw matchgroup=jinjaRawDelim start="{%\s*raw\s*%}" end="{%\s*end
 
 " Jinja comments
 syn region jinjaComment matchgroup=jinjaCommentDelim start="{#" end="#}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString,jinjaComment
-" help support folding for some setups
-setlocal commentstring={#%s#}
-setlocal comments=s:{#,e:#}
 
 " Block start keywords.  A bit tricker.  We only highlight at the start of a
 " tag block and only if the name is not followed by a comma or equals sign


### PR DESCRIPTION
This incorporates pallets/werkzeug#1164, which removes a previously added change since it apparently caused issues with multi-syntax files.

As the maintainer of Jinja, I'm removing the syntax file from the repository. See https://github.com/pallets/jinja/issues/1007#issuecomment-616146676. I don't know Vim at all, so I basically have to trust whatever PRs come in, and I don't feel comfortable keeping that. I think you're in a much better position to make decisions about the syntax file. That's not to say I want you to do any more than you currently are if you don't want to. It's absolutely fine if you don't want to enable issues and only accept PRs still.