### PR TITLE
Add Macro in the list of block tags

### DIFF
--- a/indent/jinja.vim
+++ b/indent/jinja.vim
@@ -55,7 +55,7 @@ function! GetDjangoIndent(...)
     let tagstart = '.*' . '{%\s*'
     let tagend = '.*%}' . '.*'
 
-    let blocktags = '\(block\|for\|if\|with\|autoescape\|comment\|filter\|spaceless\)'
+    let blocktags = '\(block\|for\|if\|with\|autoescape\|comment\|filter\|spaceless\|macro\)'
     let midtags = '\(empty\|else\|elif\)'
 
     let pnb_blockstart = pnb =~# tagstart . blocktags . tagend


### PR DESCRIPTION
Indentation does not work with macros, adding macro in the list of indented blocks.
