### PR TITLE
Set commentstring to the default block comment syntax.

### DIFF
--- a/ftplugin/jinja.vim
+++ b/ftplugin/jinja.vim
@@ -7,7 +7,7 @@ endif
 " TODO: useful?
 " runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
 
-setlocal comments=s:{#,ex:#} commentstring=##\ %s
+setlocal comments=s:{#,ex:#} commentstring={##\ %s
 setlocal formatoptions+=tcqln
 
 if exists('b:undo_ftplugin')


### PR DESCRIPTION
Before it was `##` which isn't even part of the Jinja syntax by default <https://jinja.palletsprojects.com/en/2.11.x/templates/#comments>.